### PR TITLE
Toggle Favorite Display

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -38,6 +38,10 @@ h3 {
   border: 2px solid #cccccc;
 }
 
+#favorited {
+  border: 5px inset #FBE75F;
+}
+
 .favorite-img {
   position: absolute;
   top: 6px;

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -41,6 +41,8 @@ export class Card extends Component {
       <div />
     );
 
+    const favorited = this.props.film.favorited;
+
     const {
       movie_id,
       title,
@@ -50,7 +52,7 @@ export class Card extends Component {
     } = this.props.film;
 
     return (
-      <article className="Card">
+      <article className="Card" id={ favorited }>
         <button
           className="favorite-img"
           id={movie_id}

--- a/src/components/CardContainer/CardContainer.js
+++ b/src/components/CardContainer/CardContainer.js
@@ -25,12 +25,14 @@ export class CardContainer extends Component {
     const filmInState = films.find(film => {
       return film.movie_id === parseInt(filmId);
     });
+    filmInState.favorited = 'favorited';
     addFavorite(filmInState);
     sendFavorite(user, filmInState);
   };
 
   handleRemoveFavorite = foundInUser => {
     const { user, removeFavorite } = this.props;
+    delete foundInUser.favorited;
     removeFavorite(foundInUser);
     deleteFavorite(user, foundInUser);
   };


### PR DESCRIPTION
On addTarget, create a property on the film object that is equal to the display id used in CSS to indicate a favorited film. On removeTarget that property is deleted so no id is rendered and the subsequent styling for favorited is not seen